### PR TITLE
Updating blueprint mapper to exclude segment blueprint element when only test is single-segmented

### DIFF
--- a/src/main/java/tds/packager/mapper/BlueprintMapper.java
+++ b/src/main/java/tds/packager/mapper/BlueprintMapper.java
@@ -111,24 +111,38 @@ public class BlueprintMapper {
                                                                       final Map<String, Scoring> scoringMap) {
         final List<BlueprintElement> segmentBlueprintElements = new ArrayList<>();
 
-        for (int i = 0; i < segmentsSheet.getTotalNumberOfInputColumns(); i++) {
-            final Map<String, String> segmentInputValuesMap = segmentsSheet.getInputVariableValuesMap(i);
+        if (isMultiSegment(segmentsSheet, assessmentId)) {
+            for (int i = 0; i < segmentsSheet.getTotalNumberOfInputColumns(); i++) {
+                final Map<String, String> segmentInputValuesMap = segmentsSheet.getInputVariableValuesMap(i);
 
-            if (!assessmentId.equals(segmentInputValuesMap.get("TestId"))) {
-                // Skip this column if it does not correspond to the assessment ID we are dealing with
-                continue;
+                if (!assessmentId.equals(segmentInputValuesMap.get("TestId"))) {
+                    // Skip this column if it does not correspond to the assessment ID we are dealing with
+                    continue;
+                }
+                final String segmentId = segmentInputValuesMap.get("SegmentId");
+
+                segmentBlueprintElements.add(BlueprintElement.builder()
+                        .setId(segmentId)
+                        .setType(BlueprintElementTypes.SEGMENT)
+                        .setScoring(Optional.ofNullable(scoringMap.get(segmentId)))
+                        .build());
+
             }
-            final String segmentId = segmentInputValuesMap.get("SegmentId");
-
-            segmentBlueprintElements.add(BlueprintElement.builder()
-                    .setId(segmentId)
-                    .setType(BlueprintElementTypes.SEGMENT)
-                    .setScoring(Optional.ofNullable(scoringMap.get(segmentId)))
-                    .build());
-
         }
 
         return segmentBlueprintElements;
+    }
+
+    private static boolean isMultiSegment(final TestPackageSheet segmentsSheet, final String assessmentId) {
+        int count = 0;
+        for (int i = 0; i < segmentsSheet.getTotalNumberOfInputColumns(); i++) {
+
+            if (assessmentId.equals(segmentsSheet.getString("TestId", i) )){
+                // Skip this column if it does not correspond to the assessment ID we are dealing with
+                count++;
+            }
+        }
+        return count > 1;
     }
 
     private static List<BlueprintElement> mapMiscellaneousElements(final TestPackageWorkbook workbook, final Map<String, Scoring> scoringMap) {

--- a/src/test/java/tds/packager/mapper/BlueprintMapperTest.java
+++ b/src/test/java/tds/packager/mapper/BlueprintMapperTest.java
@@ -140,10 +140,10 @@ public class BlueprintMapperTest extends MapperBaseTest {
         assertThat(test1BpEl.getType()).isEqualTo(BlueprintElementTypes.TEST);
         assertThat(test1BpEl.blueprintElements()).hasSize(2);
 
-        BlueprintElement seg2BpEl = rootPackageBpEl.blueprintElements().get(1);
-        assertThat(seg2BpEl.getId()).isEqualTo("SBAC-ICA-FIXED-G11M-Perf-TeenDrivingRestricitons");
-        assertThat(seg2BpEl.getType()).isEqualTo(BlueprintElementTypes.TEST);
-        assertThat(seg2BpEl.blueprintElements()).hasSize(1);
+        BlueprintElement test2BpEl = rootPackageBpEl.blueprintElements().get(1);
+        assertThat(test2BpEl.getId()).isEqualTo("SBAC-ICA-FIXED-G11M-Perf-TeenDrivingRestricitons");
+        assertThat(test2BpEl.getType()).isEqualTo(BlueprintElementTypes.TEST);
+        assertThat(test2BpEl.blueprintElements()).isEmpty();
 
         BlueprintElement claimBpEl = blueprint.stream()
                 .filter(bpEl -> bpEl.getId().equalsIgnoreCase("1"))


### PR DESCRIPTION
Single-segment tests do not need a child segment bp element, and all  bp element ids must be unique (in single-segmented test case, the test id = segment id)