### PR TITLE
Fixing mismatched blueprint reference issue for multi-segment assessments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.opentestsystem.delivery</groupId>
 	<artifactId>tds-fixed-form-packager</artifactId>
-	<version>1.0.5-SNAPSHOT</version>
+	<version>1.1.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>tds-fixed-form-packager</name>

--- a/src/main/java/tds/packager/mapper/SegmentFormMapper.java
+++ b/src/main/java/tds/packager/mapper/SegmentFormMapper.java
@@ -108,7 +108,7 @@ public class SegmentFormMapper {
                     )
                     .setTeacherHandScoring(getTeacherHandScoring(column))
                     .setItemScoreDimensions(getItemScoreDimensions(column, itemMetaDataUtil))
-                    .setBlueprintReferences(getBlueprintReferences(itemMetaDataUtil.getPrimaryStandard(), assessmentId))
+                    .setBlueprintReferences(getBlueprintReferences(itemMetaDataUtil.getPrimaryStandard(), segmentId))
                     .setPoolProperties(getPoolProperties(itemrelease, itemMetaDataUtil))
                     .setPresentations(getPresentations(itemPresentations))
                     .build());
@@ -266,7 +266,7 @@ public class SegmentFormMapper {
         }
     }
 
-    private static List<BlueprintReference> getBlueprintReferences(final String standard, final String assessmentId) {
+    private static List<BlueprintReference> getBlueprintReferences(final String standard, final String segmentId) {
         //SBAC-MA-v6:1|P|TS06|M - > 1|P|TS06|M
         final List<BlueprintReference> blueprintReferences = new ArrayList<>();
         final String bottomLevelBpRef = standard.split(":")[1];
@@ -276,7 +276,7 @@ public class SegmentFormMapper {
             blueprintReferences.add(BlueprintReference.builder().setIdRef(bottomLevelBpRef).build());
             return blueprintReferences;
         }
-        blueprintReferences.add(BlueprintReference.builder().setIdRef(assessmentId).build());
+        blueprintReferences.add(BlueprintReference.builder().setIdRef(segmentId).build());
         final List<String> refIds = new ArrayList<>();
 
         final String[] targetSections = bottomLevelBpRef.split("\\|");

--- a/src/test/java/tds/packager/mapper/SegmentFormMapperTest.java
+++ b/src/test/java/tds/packager/mapper/SegmentFormMapperTest.java
@@ -69,7 +69,7 @@ public class SegmentFormMapperTest extends MapperBaseTest {
 
         List<BlueprintReference> blueprintReferences1 = ig1Item1.getBlueprintReferences();
         assertThat(blueprintReferences1).hasSize(5);
-        assertThat(blueprintReferences1.get(0).getIdRef()).isEqualTo("SBAC-IAB-FIXED-G11M-AlgLin");
+        assertThat(blueprintReferences1.get(0).getIdRef()).isEqualTo("SBAC-IAB-FIXED-G11M-AlgLinearFun-NoCalc-MATH-11");
         assertThat(blueprintReferences1.get(1).getIdRef()).isEqualTo("1");
         assertThat(blueprintReferences1.get(2).getIdRef()).isEqualTo("1|P");
         assertThat(blueprintReferences1.get(3).getIdRef()).isEqualTo("1|P|TS03");


### PR DESCRIPTION
The blueprint reference id for items was incorrectly being set to the assessment id, when it should have actually set it to the segment id.