### PR TITLE
Fix TDS-182: Fixed Form Packager - Stimulus element not written to package file for segments having only one item

### DIFF
--- a/src/main/java/tds/packager/mapper/SegmentFormMapper.java
+++ b/src/main/java/tds/packager/mapper/SegmentFormMapper.java
@@ -346,19 +346,11 @@ public class SegmentFormMapper {
             itemList.forEach((itemId) -> {
                 itemsList.add(items.get(itemId));
             });
-            // Single Item ItemGroups don't get a Stimulus element
-            if (itemList.size() == 1) {
-                itemGroups.add(ItemGroup.builder()
-                        .setMaxResponses(Optional.of("0"))
-                        .setId(stimId)
-                        .setItems(itemsList).build());
-            } else {
-                itemGroups.add(ItemGroup.builder()
-                        .setMaxResponses(Optional.of("ALL"))
-                        .setId(stimId)
-                        .setStimulus(Optional.of(Stimulus.builder().setId(stimId).build()))
-                        .setItems(itemsList).build());
-            }
+            itemGroups.add(ItemGroup.builder()
+                    .setMaxResponses(Optional.of(itemList.size() == 1 ? "0" : "ALL"))
+                    .setId(stimId)
+                    .setStimulus(Optional.of(Stimulus.builder().setId(stimId).build()))
+                    .setItems(itemsList).build());
         });
         return itemGroups;
     }


### PR DESCRIPTION
Fixes TDS-182: https://sbacjira.atlassian.net/browse/TDS-182?oldIssueView=true

Fixed by removing special case code that does not emit Stimulus child element of ItemGroup parent element when the ItemGroup contains exactly one item.

*Note*
The existing code had a special case to not emit a Stimulus child when an ItemGroup contains exactly one item. @alexdean201 has been notified and will verify with Mark this pull request should be merged. Verify with @alexdean201 before merging this pull request. Delete this pull request if it's determined the existing behavior is actually correct.